### PR TITLE
feat: serve espeak-ng via ovos-tts-server docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+test
+**/__pycache__
+*.py[cod]
+.pytest_cache
+*.egg-info
+.venv
+TODO.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: docker
+
+on:
+  push:
+    branches: [master, dev]
+    tags: ["*.*.*", "V*", "v*"]
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - pyproject.toml
+      - .github/workflows/docker.yml
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            type=ref,event=tag
+            type=sha,format=short
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,37 @@
+# espeak-ng speech synthesis served through ovos-tts-server's ElevenLabs-compatible
+# API. A self-contained, fully offline image: any client that speaks the
+# ovos-tts-server / ElevenLabs API can hit it, and it can be A/B-tested against other
+# ovos-tts-server voices (phoonnx, edge-tts, omnivoice, ...) by pointing at a different
+# port.
+#
+# espeak-ng is an offline synthesizer, so this container needs no network access at
+# runtime.
 FROM python:3.11-slim
 
-RUN apt-get update && \
-  apt-get install -y git build-essential espeak-ng && \
-  rm -rf /var/lib/apt/lists/*
+# espeak-ng: the synthesizer binary the plugin shells out to. It emits WAV directly,
+# so no ffmpeg transcoding is needed.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        espeak-ng \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install ovos-tts-server
+WORKDIR /app
+COPY . /app
 
-COPY . /tmp/ovos-tts-plugin-espeakng
-RUN pip3 install /tmp/ovos-tts-plugin-espeakng
+# the plugin + the OVOS TTS server. setuptools<81 keeps ovos-plugin-manager's
+# pkg_resources usage working. ovos-tts-server>=1.13.5a1's alpha floor lets pip resolve
+# the prerelease without --pre.
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir "setuptools<81" "." "ovos-tts-server>=1.13.5a1"
 
-ENTRYPOINT ovos-tts-server --engine ovos-tts-plugin-espeakng
+# Default language, overridable with the LANG build arg (any espeak-ng lang works).
+ARG LANG=en-us
+RUN useradd -m -u 1000 ovos \
+    && mkdir -p /home/ovos/.config/mycroft \
+    && printf '{\n  "tts": {\n    "module": "ovos-tts-plugin-espeakng",\n    "ovos-tts-plugin-espeakng": {\n      "lang": "%s",\n      "voice": "m1"\n    }\n  }\n}\n' "${LANG}" \
+        > /home/ovos/.config/mycroft/mycroft.conf \
+    && chown -R 1000:1000 /home/ovos/.config
+USER 1000
+
+EXPOSE 9666
+ENTRYPOINT ["ovos-tts-server", "--engine", "ovos-tts-plugin-espeakng", \
+            "--host", "0.0.0.0", "--port", "9666", "--cache"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  espeakng-tts:
+    image: ghcr.io/openvoiceos/ovos-tts-plugin-espeakng:latest
+    # …or build locally: build: .
+    container_name: espeakng-tts
+    restart: unless-stopped
+    ports:
+      - "9666:9666"
+    # optional: override the served language
+    # environment: {}  # (lang is a build arg; rebuild with --build-arg LANG=pt)
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9666/status')"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s

--- a/readme.md
+++ b/readme.md
@@ -29,14 +29,32 @@ apt-get install espeak-ng
 
 ## Docker
 
-build it
+This plugin ships a self-contained image that serves espeak-ng behind
+[ovos-tts-server](https://github.com/OpenVoiceOS/ovos-tts-server)'s
+ElevenLabs-compatible HTTP API on port `9666`. espeak-ng runs fully offline, so the
+container needs no network access or API keys at runtime.
+
+Pull the published image:
+
 ```bash
-docker build . -t ovos/espeakng
+docker run --rm -p 9666:9666 ghcr.io/openvoiceos/ovos-tts-plugin-espeakng:dev
 ```
 
-run it
+…or build it locally, optionally overriding the default language:
+
 ```bash
-docker run -p 8080:9666 ovos/espeakng
+docker build -t ovos-tts-plugin-espeakng --build-arg LANG=pt .
+docker run --rm -p 9666:9666 ovos-tts-plugin-espeakng
 ```
 
-use it `http://localhost:8080/synthesize/hello`
+…or use the bundled compose file:
+
+```bash
+docker compose up
+```
+
+Synthesize speech:
+
+```bash
+curl 'http://localhost:9666/synthesize/hello%20world' --output hello.wav
+```


### PR DESCRIPTION
Adds a self-contained container that serves this plugin behind [ovos-tts-server](https://github.com/OpenVoiceOS/ovos-tts-server)'s ElevenLabs-compatible API on port 9666, published to `ghcr.io/openvoiceos/ovos-tts-plugin-espeakng` from CI.

- Replaces the stale ad-hoc `Dockerfile` with a proper `python:3.11-slim` image (non-root user, mycroft.conf, `LANG` build arg).
- espeak-ng runs fully offline and emits WAV directly, so no ffmpeg or network access is needed at runtime.
- Adds `.dockerignore`, `docker-compose.yml`, a `docker` CI workflow (build on PR, build+push on dev/master/tags), and a README Docker section.